### PR TITLE
Convert a 'git describe' version to something that makes rpm versioni…

### DIFF
--- a/.github/workflows/nnf-rpm.yml
+++ b/.github/workflows/nnf-rpm.yml
@@ -4,7 +4,7 @@ on: push
 
 env:
   STARTS_WITH_RELEASES: 'refs/heads/releases/nnf'
-  SWITCHTEC_LIB_PKG: https://github.com/NearNodeFlash/switchtec-user/releases/download/4.2-rc1-8-gf5ad807/switchtec-4.2-0.rc1.8.gf5ad807.el8.x86_64.rpm
+  SWITCHTEC_LIB_PKG: https://github.com/NearNodeFlash/switchtec-user/releases/download/4.2-rc1-12-g531565a/switchtec-4.2-0.rc1_12HPE.el8.x86_64.rpm
 
 jobs:
   build-rpm:

--- a/NVME-VERSION-GEN
+++ b/NVME-VERSION-GEN
@@ -31,7 +31,24 @@ VN=$(expr "$VN" : v*'\(.*\)')
 OVN=$(expr "$OVN" : v*'\(.*\)')
 MVN=$(expr "$OVN" : v*'\([0-9.]*\)')
 RVN=$(expr "$OVN" : v*'[0-9.]*\-\(.*\)')
-test -n "$RVN" && RDVN=0.$(echo "$RVN" | sed -e 's/-/./g') || RDVN="1"
+
+# Add a "0." prefix to the release ID, but don't allow it to be doubled-up when
+# this script is called multiple times during a build.
+if [[ -n $RVN && $RVN =~ ^0 ]]
+then
+    RDVN=$(echo "$RVN" | sed -e 's/-/./g')
+elif [[ -n $RVN ]]
+then
+    RDVN=0.$(echo "$RVN" | sed -e 's/-/./g')
+else
+    RDVN="1"
+fi
+
+# Convert a 'git describe' version to something that makes rpm versioning
+# happy:
+#    4.2-rc1-26-ge1dc405 => 4.2-0~rc1_26HPE
+#    0.5.17.g8e16 => 0.5-0~17HPE
+HPE_RDVN=$(echo "0~$RVN" | sed -e 's/\([0-9][0-9]*\)\-g.*$/\1HPE/' -e 's/\-/_/g')
 
 if test -r $GVF
 then
@@ -44,7 +61,8 @@ test "$VN" = "$VC" || {
 	echo "NVME_VERSION = $VN" >$GVF
 	echo "DOTDASH_VERSION = $OVN" >>$GVF
 	echo "SPEC_VERSION = $MVN" >>$GVF
-	echo "SPEC_RELEASE = $RDVN" >>$GVF
+	echo "SPEC_RELEASE_ORIG = $RDVN" >>$GVF
+	echo "SPEC_RELEASE = $HPE_RDVN" >>$GVF
 }
 
 


### PR DESCRIPTION
…ng happy

This is focused primarily on the version-release value that RPM will use to compare versions of rpm packaging.  The filenames of the rpm bundle are affected slightly as a side-effect, and any further massaging of those names is reserved for another effort.