### PR TITLE
Construct RPM version field

### DIFF
--- a/.github/workflows/nnf-rpm.yml
+++ b/.github/workflows/nnf-rpm.yml
@@ -4,7 +4,7 @@ on: push
 
 env:
   STARTS_WITH_RELEASES: 'refs/heads/releases/nnf'
-  SWITCHTEC_LIB_PKG: https://github.com/NearNodeFlash/switchtec-user-rpmexp-43/releases/download/4.2-rc1_29HPE/switchtec-4.2.rc1_29HPE-1.el8.x86_64.rpm
+  SWITCHTEC_LIB_PKG: https://github.com/NearNodeFlash/switchtec-user/releases/download/v4.2-rc1_15HPE/switchtec-4.2.rc1_15HPE-1.el8.x86_64.rpm
 
 jobs:
   build-rpm:

--- a/.github/workflows/nnf-rpm.yml
+++ b/.github/workflows/nnf-rpm.yml
@@ -4,7 +4,7 @@ on: push
 
 env:
   STARTS_WITH_RELEASES: 'refs/heads/releases/nnf'
-  SWITCHTEC_LIB_PKG: https://github.com/NearNodeFlash/switchtec-user/releases/download/4.2-rc1-12-g531565a/switchtec-4.2-0.rc1_12HPE.el8.x86_64.rpm
+  SWITCHTEC_LIB_PKG: https://github.com/NearNodeFlash/switchtec-user-rpmexp-43/releases/download/4.2-rc1_29HPE/switchtec-4.2.rc1_29HPE-1.el8.x86_64.rpm
 
 jobs:
   build-rpm:
@@ -58,13 +58,14 @@ jobs:
         #      0.5-53-g0e90
         run: |
           ./NVME-VERSION-GEN
-          sed 1q NVME-VERSION-FILE | awk '{print $3}' > version
-          echo "versionDotted=$(grep DOTDASH_VERSION NVME-VERSION-FILE | awk '{print $3}')" >> $GITHUB_ENV
-          echo "versionDashed=$(sed 's/\./-/g' version)" >> $GITHUB_ENV
-          echo ---
+          echo "--- NVME-VERSION-FILE begin"
           cat NVME-VERSION-FILE
-          echo ---
-          cat version
+          echo "--- NVME-VERSION-FILE end"
+
+          echo "release_tag=$(grep -E '^RELEASE_TAG =' NVME-VERSION-FILE | awk '{print $3}')" >> $GITHUB_ENV
+          grep -E '^NVME_VERSION =' NVME-VERSION-FILE | awk '{print $3}' > version
+          echo "versionDotted=$(<version)" >> $GITHUB_ENV
+          echo "versionDashed=$(sed 's/\./-/g' version)" >> $GITHUB_ENV
 
       - name: make source tarball
         run: make dist
@@ -116,7 +117,7 @@ jobs:
         if: ${{ startsWith(github.ref, env.STARTS_WITH_RELEASES) }}
         uses: tvdias/github-tagger@v0.0.1
         with:
-          tag: ${{ env.versionDotted }}
+          tag: ${{ env.release_tag }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: upload the release assets
         # These can be found by going to the repo's "Releases" page.
@@ -124,7 +125,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ env.versionDotted }}
-          tag_name: ${{ env.versionDotted }}
+          tag_name: ${{ env.release_tag }}
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: /tmp/artifacts/*

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ QUIET_CC=
 
 default: $(NVME)
 
-NVME-VERSION-FILE: FORCE
+NVME-VERSION-FILE:
 	@$(SHELL_PATH) ./NVME-VERSION-GEN
 -include NVME-VERSION-FILE
 override CFLAGS += -DNVME_VERSION='"$(NVME_VERSION)"'
@@ -171,14 +171,14 @@ install-spec: install-bin install-man install-bash-completion install-zsh-comple
 install: install-spec install-hostparams
 
 $(NVME).spec: nvme.spec.in NVME-VERSION-FILE
-	sed -e 's/@@VERSION@@/$(SPEC_VERSION)/g' < $< | sed -e 's/@@RELEASE@@/$(SPEC_RELEASE)/g' > $@+
+	sed -e 's/@@VERSION@@/$(NVME_VERSION)/g' < $< | sed -e 's/@@RELEASE@@/$(SPEC_RELEASE)/g' > $@+
 	mv $@+ $@
 
 70-nvmf-autoconnect.conf: nvmf-autoconnect/dracut-conf/70-nvmf-autoconnect.conf.in
 	sed -e 's#@@UDEVRULESDIR@@#$(UDEVRULESDIR)#g' < $< > $@+
 	mv $@+ $@
 
-PKG=$(NVME)-$(SPEC_VERSION)-$(SPEC_RELEASE)
+PKG=$(NVME)-$(NVME_VERSION)-$(SPEC_RELEASE)
 dist: $(NVME).spec
 	git archive --format=tar --prefix=$(PKG)/ HEAD > $(PKG).tar
 	@echo $(NVME_VERSION) > version
@@ -243,4 +243,4 @@ rpm: dist
 	$(RPMBUILD) --define '_libdir ${LIBDIR}' -ta $(PKG).tar.gz
 
 .PHONY: default doc all clean clobber install-man install-bin install
-.PHONY: dist pkg dist-orig deb deb-light rpm FORCE test
+.PHONY: dist pkg dist-orig deb deb-light rpm test

--- a/NVME-VERSION-GEN
+++ b/NVME-VERSION-GEN
@@ -40,10 +40,10 @@ RDVN=1
 HPE_VN_1=$(echo "$RVN" | sed -e 's/\([0-9][0-9]*\)\-g.*$/\1HPE/' -e 's/\-/_/g')
 if [[ -n $HPE_VN_1 && ! $HPE_VN_1 =~ ^_ ]]
 then
-    HPE_TAG="$MVN-${HPE_VN_1}"
+    HPE_TAG="v$MVN-${HPE_VN_1}"
     HPE_VN="$MVN~${HPE_VN_1}"
 else
-    HPE_TAG="$HPE_VN_1"
+    HPE_TAG="v$HPE_VN_1"
     HPE_VN="$MVN${HPE_VN_1}"
 fi
 

--- a/NVME-VERSION-GEN
+++ b/NVME-VERSION-GEN
@@ -30,25 +30,22 @@ fi
 VN=$(expr "$VN" : v*'\(.*\)')
 OVN=$(expr "$OVN" : v*'\(.*\)')
 MVN=$(expr "$OVN" : v*'\([0-9.]*\)')
-RVN=$(expr "$OVN" : v*'[0-9.]*\-\(.*\)')
-
-# Add a "0." prefix to the release ID, but don't allow it to be doubled-up when
-# this script is called multiple times during a build.
-if [[ -n $RVN && $RVN =~ ^0 ]]
-then
-    RDVN=$(echo "$RVN" | sed -e 's/-/./g')
-elif [[ -n $RVN ]]
-then
-    RDVN=0.$(echo "$RVN" | sed -e 's/-/./g')
-else
-    RDVN="1"
-fi
+RVN=$(expr "$OVN" : v*'[0-9.]*[-~]\(.*\)')
+RDVN=1
 
 # Convert a 'git describe' version to something that makes rpm versioning
 # happy:
-#    4.2-rc1-26-ge1dc405 => 4.2-0~rc1_26HPE
-#    0.5.17.g8e16 => 0.5-0~17HPE
-HPE_RDVN=$(echo "0~$RVN" | sed -e 's/\([0-9][0-9]*\)\-g.*$/\1HPE/' -e 's/\-/_/g')
+#    4.2-rc1-26-ge1dc405 => 4.2~rc1_26HPE
+#    0.5.17.g8e16 => 0.5_17HPE
+HPE_VN_1=$(echo "$RVN" | sed -e 's/\([0-9][0-9]*\)\-g.*$/\1HPE/' -e 's/\-/_/g')
+if [[ -n $HPE_VN_1 && ! $HPE_VN_1 =~ ^_ ]]
+then
+    HPE_TAG="$MVN-${HPE_VN_1}"
+    HPE_VN="$MVN~${HPE_VN_1}"
+else
+    HPE_TAG="$HPE_VN_1"
+    HPE_VN="$MVN${HPE_VN_1}"
+fi
 
 if test -r $GVF
 then
@@ -57,12 +54,10 @@ else
 	VC=unset
 fi
 test "$VN" = "$VC" || {
-	echo >&2 "NVME_VERSION = $VN"
-	echo "NVME_VERSION = $VN" >$GVF
-	echo "DOTDASH_VERSION = $OVN" >>$GVF
-	echo "SPEC_VERSION = $MVN" >>$GVF
-	echo "SPEC_RELEASE_ORIG = $RDVN" >>$GVF
-	echo "SPEC_RELEASE = $HPE_RDVN" >>$GVF
+	echo >&2 "NVME_VERSION = $HPE_VN"
+	echo "NVME_VERSION = $HPE_VN" >$GVF
+	echo "SPEC_RELEASE = $RDVN" >>$GVF
+	echo "RELEASE_TAG = $HPE_TAG" >>$GVF
 }
 
 


### PR DESCRIPTION
Convert the git-describe into an RPM version field. 4.2-rc1-26-ge1dc405 => 4.2~rc1_26HPE
0.5.17.g8e16 => 0.5_17HPE

Set the RPM release field to 1.

Fix makefile looping by removing FORCE on the NVME-VERSION-FILE target.